### PR TITLE
iOS 添加对 object 类型支持

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,7 @@
 ## 0.6.5
 
 * Feat: Objective-C support convert 'Object' type to 'id'
+
+# 0.6.6
+
+* Fix: 'void' type convert to 'void *' in objc instead of 'void' problem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,7 @@
 ## 0.6.4
 
 * fix: dart null safe bug
+
+## 0.6.5
+
+* Feat: Objective-C support convert 'Object' type to 'id'

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ List< T > |✅|ArrayList<>|NSArray|
 Map<T, U>|✅|HashMap<T, U>|NSDictionary|
 var|❌||
 dynamic|❌||
-Object|❌||
+Object|✅|❌|id|
 Custom Class|✅||
 
 #### Note: Currently don't support `List a= [];`, because it's the same as `List<dynamic> a =[];`, , and `dynamic` feature doesn't support, `Map` is same.

--- a/README_CN.md
+++ b/README_CN.md
@@ -150,7 +150,7 @@ List< T > |✅|ArrayList<>|NSArray|
 Map<T, U>|✅|HashMap<T, U>|NSDictionary
 var|❌||
 dynamic|❌||
-Object|❌||
+Object|✅|❌|id|
 自定义类|✅||
 
 #### 注意: 不支持 `List a= [];`, 因为语句等同于 `List<dynamic> a =[];`, 而 dynamic 类型是不支持的, Map 同样如此<br><br><br>

--- a/lib/example/example.dart
+++ b/lib/example/example.dart
@@ -1,5 +1,5 @@
 abstract class IAccount {
-  Future<String?> login(String? name, String password);
+  Future<String?> login(String? name, Object password);
 
   Future<String?> getToken();
 

--- a/lib/ios_gen.dart
+++ b/lib/ios_gen.dart
@@ -28,6 +28,7 @@ class ObjectiveCCreate {
     "dart.core.Map": "NSDictionary",
     "number": "NSNumber",
     "void": "void",
+    "dart.core.Object": "id",
   };
   static const Map<String, String> specialTypeMap = {
     "dart.async.Future": "",
@@ -301,7 +302,10 @@ class ObjectiveCCreate {
         if (property.subType.isNotEmpty) {
           propertyString += getSubTypeString(property);
         }
-        propertyString += " *";
+        propertyString += " ";
+        if (!isObjectType(property)) {
+          propertyString += "*";
+        }
         break;
       case ObjectivePropertType.customClass:
         propertyString += "strong";
@@ -366,7 +370,10 @@ class ObjectiveCCreate {
           String subTypeString = getSubTypeString(property);
           typeString += subTypeString;
         }
-        typeString += " *";
+        typeString += " ";
+        if (!isObjectType(property)) {
+          typeString += "*";
+        }
         break;
       case ObjectivePropertType.specialType:
         typeString = getTypeString(property.subType.first);
@@ -380,6 +387,10 @@ class ObjectiveCCreate {
         typeString += " *";
     }
     return typeString;
+  }
+
+  static bool isObjectType(Property property) {
+    return property.type == "dart.core.Object";
   }
 
   /// save all content use shell

--- a/lib/ios_gen.dart
+++ b/lib/ios_gen.dart
@@ -303,7 +303,7 @@ class ObjectiveCCreate {
           propertyString += getSubTypeString(property);
         }
         propertyString += " ";
-        if (!isObjectType(property)) {
+        if (!isBaseClassObjectType(property)) {
           propertyString += "*";
         }
         break;
@@ -371,8 +371,8 @@ class ObjectiveCCreate {
           typeString += subTypeString;
         }
         typeString += " ";
-        if (!isObjectType(property)) {
-          typeString += "*";
+        if (!isBaseClassObjectType(property)) {
+          typeString += " *";
         }
         break;
       case ObjectivePropertType.specialType:
@@ -389,8 +389,8 @@ class ObjectiveCCreate {
     return typeString;
   }
 
-  static bool isObjectType(Property property) {
-    return property.type == "dart.core.Object";
+  static bool isBaseClassObjectType(Property property) {
+    return property.type == "dart.core.Object" || property.type == "void";
   }
 
   /// save all content use shell

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platforms_source_gen
 description: A Flutter package gen platform's source code, include Android or iOS, Web ....
-version: 0.6.4
+version: 0.6.5
 homepage: https://github.com/siyehua/platforms_source_gen
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: platforms_source_gen
 description: A Flutter package gen platform's source code, include Android or iOS, Web ....
-version: 0.6.5
+version: 0.6.6
 homepage: https://github.com/siyehua/platforms_source_gen
 
 environment:


### PR DESCRIPTION
不在spi flutter package 做了，因为iOS需要处理头文件引用等问题，直接在这里处理成id类型更方便后续接入